### PR TITLE
Automatically copy dev MySQL DB

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,12 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E303" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.13" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/rds-snapshot-export-to-s3-pipeline.iml" filepath="$PROJECT_DIR$/.idea/rds-snapshot-export-to-s3-pipeline.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/rds-snapshot-export-to-s3-pipeline.iml
+++ b/.idea/rds-snapshot-export-to-s3-pipeline.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/assets/exporter/main.py
+++ b/assets/exporter/main.py
@@ -116,7 +116,8 @@ def process_automated_snapshot(message, message_id, db_snapshot_type):
     account_id = boto3.client("sts").get_caller_identity()["Account"]
 
     export_task_identifier = (message["Source ID"][4:27] + '-').replace("--", "-") + message_id
-    source_arn = f"arn:aws:rds:{AWS_REGION}:{account_id}:{db_snapshot_type}:{message['Source ID']}"
+    source_arn = (f"arn:aws:rds:{AWS_REGION}:{account_id}:cluster-{db_snapshot_type}"
+                  f":{message['Source ID']}")
 
     start_export_task(export_task_identifier, source_arn) 
 
@@ -125,7 +126,7 @@ def process_manual_snapshot(message, message_id, db_snapshot_type):
     account_id = boto3.client("sts").get_caller_identity()["Account"]
 
     export_task_identifier = (message["Source ID"][:24] + '-').replace("--", "-") + message_id
-    source_arn = f"arn:aws:rds:{AWS_REGION}:{account_id}:{db_snapshot_type}:{message['Source ID']}"
+    source_arn = f"arn:aws:rds:{AWS_REGION}:{account_id}:cluster-{db_snapshot_type}:{message['Source ID']}"
 
     start_export_task(export_task_identifier, source_arn) 
 

--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -5,7 +5,7 @@ import { RdsSnapshotExportPipelineStack, RdsEventId, RdsSnapshotType } from '../
 
 const app = new cdk.App();
 new RdsSnapshotExportPipelineStack(app, 'RdsSnapshotExportToS3Pipeline', {
-  dbName: '<existing-rds-database-name>',
+  dbName: 'spotship-dev2-cluster',
   rdsEvents:
     [
       {
@@ -13,5 +13,5 @@ new RdsSnapshotExportPipelineStack(app, 'RdsSnapshotExportToS3Pipeline', {
         rdsSnapshotType: RdsSnapshotType.DB_AUTOMATED_SNAPSHOT
       }
     ],
-  s3BucketName: '<desired-s3-bucket-name>',
+  s3BucketName: 'spot-ship-dev-db-backups',
 });

--- a/event.aurora.json
+++ b/event.aurora.json
@@ -5,7 +5,7 @@
             "Sns": {
                 "Type": "Notification",
                 "MessageId": "00000000-0000-0000-0000-000000000000",
-                "Message": "{\"Event Source\":\"db-cluster-snapshot\",\"Source ID\":\"<SNAPSHOT_NAME>\",\"Event ID\":\"http://docs.amazonwebservices.com/AmazonRDS/latest/UserGuide/USER_Events.html#RDS-EVENT-0169\"}"
+                "Message": "{\"Event Source\":\"db-cluster-snapshot\",\"Source ID\":\"rds:spotship-dev2-cluster-2024-10-09-04-20\",\"Event ID\":\"http://docs.amazonwebservices.com/AmazonRDS/latest/UserGuide/USER_Events.html#RDS-EVENT-0169\"}"
             }
         }
     ]


### PR DESCRIPTION
chore: Configure for Spot Ship
fix: Lambda seems confused between Aurora and regular DB events, and I'm not invested enough in AWS's FOSS reputation to fix it, so I'm not fixing it properly (today)

This Lambda runs every time the database is snapshotted, and copies the backup to the s3 bucket `spot-ship-dev-db-backups`.
https://eu-west-2.console.aws.amazon.com/lambda/home?region=eu-west-2#/functions/spotship-dev2-cluster-rds-snapshot-exporter?tab=code